### PR TITLE
plugin toc: Add limit parameter

### DIFF
--- a/lib/daimon/markdown/plugin/toc.rb
+++ b/lib/daimon/markdown/plugin/toc.rb
@@ -4,7 +4,7 @@ module Daimon
       class TableOfContents < Base
         Plugin.register("toc", self)
 
-        def call
+        def call(limit = nil)
           toc_html = ""
           items = []
 
@@ -12,6 +12,7 @@ module Daimon
           previous_level = 1
           doc.css("h1, h2, h3, h4, h5, h6").each do |header_node|
             level = header_node.name.tr("h", "").to_i
+            next if limit && limit < level
             text = header_node.text
             id = text.downcase
             id.gsub!(/ /, "-")

--- a/test/plugin/test_toc.rb
+++ b/test/plugin/test_toc.rb
@@ -111,6 +111,39 @@ class TocTest < Test::Unit::TestCase
     assert_toc(expected_toc_html, expected_header_ids, markdown)
   end
 
+  def test_limit
+    markdown = <<~TEXT
+
+    {{toc(2)}}
+    
+    # title
+
+    This is a text
+
+    ## title 2
+
+    ### title 3
+    
+    This is a text
+
+    # title 1
+
+    This is a text
+    TEXT
+    
+    expected_toc_html = <<~HTML.chomp
+    <ul class="section-nav">
+    <li><a href="#title">title</a></li>
+    <ul>
+    <li><a href="#title-2">title 2</a></li>
+    </ul>
+    <li><a href="#title-1">title 1</a></li>
+    </ul>
+    HTML
+    expected_header_ids = ["title", "title-2", "title-1"]
+    assert_toc(expected_toc_html, expected_header_ids, markdown)
+  end
+
   private
 
   def assert_toc(expected_toc_html, expected_header_ids, markdown)
@@ -118,7 +151,7 @@ class TocTest < Test::Unit::TestCase
     actual_toc_html = result[:output].search("ul").first.to_s
     actual_header_ids = result[:output].search("h1, h2, h3, h4, h5, h6").map do |node|
       node["id"]
-    end
+    end.compact
     assert_equal(expected_toc_html, actual_toc_html)
     assert_equal(expected_header_ids, actual_header_ids)
   end


### PR DESCRIPTION
Example:

```
{{toc(3)}}
```

This generates table of contents using h1, h2 and h3.
