### PR TITLE
Update mathjax CDN url

### DIFF
--- a/lib/daimon_markdown/plugin/math.rb
+++ b/lib/daimon_markdown/plugin/math.rb
@@ -14,7 +14,7 @@ module DaimonMarkdown
         </script>
         <script type="text/javascript"
                 async
-                src="https://cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_CHTML">
+                src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.6.1/MathJax.js?config=TeX-MML-AM_CHTML">
         </script>
         TAG
         if tag.respond_to?(:html_safe)


### PR DESCRIPTION
Like https://github.com/bm-sms/daimon_markdown/pull/11, use cdnjs CDN based on http://docs.mathjax.org/en/latest/start.html

&& pin MathJax library version to 2.6.1